### PR TITLE
Update Outrig Cask for v0.6.2 Release

### DIFF
--- a/Casks/outrig.rb
+++ b/Casks/outrig.rb
@@ -1,14 +1,14 @@
 cask "outrig" do
-  version "0.6.1"
+  version "0.6.2"
   
   on_intel do
-    url "https://github.com/outrigdev/outrig/releases/download/v0.6.1/Outrig-darwin-amd64-v0.6.1.dmg"
-    sha256 "87940c141ffc76812ebb12b32880e4a8bde061bba168c146b17e0984bd11db13"
+    url "https://github.com/outrigdev/outrig/releases/download/v0.6.2/Outrig-darwin-amd64-v0.6.2.dmg"
+    sha256 "deb1292068cc3c4b9a1f8583c512591888e79472ed78fbbc89dbfdb5a508a57a"
   end
   
   on_arm do
-    url "https://github.com/outrigdev/outrig/releases/download/v0.6.1/Outrig-darwin-arm64-v0.6.1.dmg"
-    sha256 "d63cc63ea6436a82a548dff8990a521cae09e4ae2a4de3f4ad0ddfe4825648d3"
+    url "https://github.com/outrigdev/outrig/releases/download/v0.6.2/Outrig-darwin-arm64-v0.6.2.dmg"
+    sha256 "73d8e2458d1d2a408a4bf0b129346dca6ba4a3563354bc5c4d99bccf5cebcb55"
   end
 
   name "Outrig"


### PR DESCRIPTION
Automated update of Outrig cask for release v0.6.2