### PR TITLE
Update Outrig Cask for v0.6.3 Release

### DIFF
--- a/Casks/outrig.rb
+++ b/Casks/outrig.rb
@@ -1,14 +1,14 @@
 cask "outrig" do
-  version "0.6.2"
+  version "0.6.3"
   
   on_intel do
-    url "https://github.com/outrigdev/outrig/releases/download/v0.6.2/Outrig-darwin-amd64-v0.6.2.dmg"
-    sha256 "deb1292068cc3c4b9a1f8583c512591888e79472ed78fbbc89dbfdb5a508a57a"
+    url "https://github.com/outrigdev/outrig/releases/download/v0.6.3/Outrig-darwin-amd64-v0.6.3.dmg"
+    sha256 "059ed0359953a1c512acc2cef84f39b7720ff5687a2c2146a676db16de540389"
   end
   
   on_arm do
-    url "https://github.com/outrigdev/outrig/releases/download/v0.6.2/Outrig-darwin-arm64-v0.6.2.dmg"
-    sha256 "73d8e2458d1d2a408a4bf0b129346dca6ba4a3563354bc5c4d99bccf5cebcb55"
+    url "https://github.com/outrigdev/outrig/releases/download/v0.6.3/Outrig-darwin-arm64-v0.6.3.dmg"
+    sha256 "0ef7eeb751f146206c8d6b30a2d26b12f1a4d6baa62c6f6496c828f2b0f338e8"
   end
 
   name "Outrig"


### PR DESCRIPTION
Automated update of Outrig cask for release v0.6.3