### PR TITLE
Update Outrig Cask for v0.9.0 Release

### DIFF
--- a/Casks/outrig.rb
+++ b/Casks/outrig.rb
@@ -1,14 +1,14 @@
 cask "outrig" do
-  version "0.8.3"
+  version "0.9.0"
   
   on_intel do
-    url "https://github.com/outrigdev/outrig/releases/download/v0.8.3/Outrig-darwin-amd64-v0.8.3.dmg"
-    sha256 "6d33a5e98715dd3b780a945e9521d874711c4c9d5a6844412207afe77a159c98"
+    url "https://github.com/outrigdev/outrig/releases/download/v0.9.0/Outrig-darwin-amd64-v0.9.0.dmg"
+    sha256 "b2b945b01a6583350b1bc0b543e025caefb7143e6a6cde49df2781c937b506b1"
   end
   
   on_arm do
-    url "https://github.com/outrigdev/outrig/releases/download/v0.8.3/Outrig-darwin-arm64-v0.8.3.dmg"
-    sha256 "650913604a04036c9a5b1fd49820a43ba49b55730e789cf177e8c1b850c90187"
+    url "https://github.com/outrigdev/outrig/releases/download/v0.9.0/Outrig-darwin-arm64-v0.9.0.dmg"
+    sha256 "242bfe47d9272964388ce748fde6630f538cd4b2098ce6f6e6770cb146ec06f4"
   end
 
   name "Outrig"


### PR DESCRIPTION
Automated update of Outrig cask for release v0.9.0